### PR TITLE
Change behaviour of timing_response in plugin multi-stim-multi-response

### DIFF
--- a/plugins/jspsych-multi-stim-multi-response.js
+++ b/plugins/jspsych-multi-stim-multi-response.js
@@ -203,11 +203,17 @@
 				allow_held_key: false
       });
 
+      // calculate total trial time
+      var total_time = 0;
+      for (var i = 0; i < trial.stimuli.length; i++) {
+        total_time += trial.timing_stim[i];
+      }
+      
       // end trial if time limit is set
       if (trial.timing_response > 0) {
         var t2 = setTimeout(function() {
           end_trial();
-        }, trial.timing_response);
+        }, total_time + trial.timing_response);
         setTimeoutHandlers.push(t2);
       }
 


### PR DESCRIPTION
Old behaviour: timing_response is measured from the start of the trial
New behaviour: timing_response is measured from the end of stimulus presentation

Why?
Ending a trial on a missing response before the end of stimulus presentation is not needed  - in this case, one could just change the duration of stimulus presentation to achieve the same effect.
However, trials can consist of a different amount of stimuli - which results in different total trial lengths. Therefore setting a constant post stimulus presentation interval for response collection was not possible, so far.